### PR TITLE
Adds better checking & handling of bad responses

### DIFF
--- a/spec/Inviqa/IMICampaign/Exception/UnknownResponseExceptionSpec.php
+++ b/spec/Inviqa/IMICampaign/Exception/UnknownResponseExceptionSpec.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace spec\Inviqa\IMICampaign\Exception;
+
+use Inviqa\IMICampaign\Exception\UnknownResponseException;
+use PhpSpec\ObjectBehavior;
+
+class UnknownResponseExceptionSpec extends ObjectBehavior
+{
+    const EXAMPLE_RESPONSE_BODY = 'Erroneous response body!';
+
+    function it_can_easily_be_constructed_with_the_response_body()
+    {
+        $this->beConstructedWithResponseBody(self::EXAMPLE_RESPONSE_BODY);
+        $this->getMessage()->shouldBe(sprintf(UnknownResponseException::UNKNOWN_RESPONSE_MESSAGE, self::EXAMPLE_RESPONSE_BODY));
+    }
+}

--- a/spec/Inviqa/IMICampaign/Response/ResponseParserSpec.php
+++ b/spec/Inviqa/IMICampaign/Response/ResponseParserSpec.php
@@ -26,11 +26,23 @@ class ResponseParserSpec extends ObjectBehavior
         $this->extractEventResultFrom($responseBody)->shouldBeLike($eventResult);
     }
 
-    function it_throws_an_exception_if_unable_to_identify_the_response()
+    function it_throws_an_exception_if_unable_to_identify_the_response_when_it_is_an_array()
     {
+        $responseBody = '{"bad-response": "yes"}';
+
         $this
-            ->shouldThrow(new UnknownResponseException(ResponseParser::UNKNOWN_RESPONSE_MESSAGE))
-            ->duringExtractEventResultFrom('{"bad-response": "yes"}')
+            ->shouldThrow(UnknownResponseException::withResponseBody($responseBody))
+            ->duringExtractEventResultFrom($responseBody)
+        ;
+    }
+
+    function it_throws_an_exception_if_unable_to_identify_the_response_when_it_cannot_be_json_decoded()
+    {
+        $responseBody = 'Bad Response!';
+
+        $this
+            ->shouldThrow(UnknownResponseException::withResponseBody($responseBody))
+            ->duringExtractEventResultFrom($responseBody)
         ;
     }
 }

--- a/src/Inviqa/IMICampaign/Exception/UnknownResponseException.php
+++ b/src/Inviqa/IMICampaign/Exception/UnknownResponseException.php
@@ -4,4 +4,11 @@ namespace Inviqa\IMICampaign\Exception;
 
 class UnknownResponseException extends IMICampaignException
 {
+    public const UNKNOWN_RESPONSE_MESSAGE = 'Unknown response returned from the API: "%s"';
+
+    public static function withResponseBody(?string $responseBody): UnknownResponseException
+    {
+        $exception = new static(sprintf(self::UNKNOWN_RESPONSE_MESSAGE, $responseBody));
+        return $exception;
+    }
 }

--- a/src/Inviqa/IMICampaign/Response/ResponseParser.php
+++ b/src/Inviqa/IMICampaign/Response/ResponseParser.php
@@ -7,11 +7,13 @@ use function json_decode;
 
 class ResponseParser
 {
-    public const UNKNOWN_RESPONSE_MESSAGE = 'Unable to build a result from the response';
-
     public function extractEventResultFrom(string $responseBody): EventResult
     {
         $decodedResponse = json_decode($responseBody, true);
+
+        if (! is_array($decodedResponse)) {
+            throw UnknownResponseException::withResponseBody($responseBody);
+        }
 
         if (array_key_exists('transaction-id', $decodedResponse)) {
             return EventResult::successFromTransactionId($decodedResponse['transaction-id']);
@@ -24,6 +26,6 @@ class ResponseParser
             );
         }
 
-        throw new UnknownResponseException(self::UNKNOWN_RESPONSE_MESSAGE);
+        throw UnknownResponseException::withResponseBody($responseBody);
     }
 }


### PR DESCRIPTION
I realised I wasn't handling the case where the result would not be able to be `json_decode`d, and then the `array_key_exists` checks would blow up as they'd be passed `null`.

I added a check for that, and also updated the exception to consume the response body so it doesn't just get lost to the ether and we can log it if needed.